### PR TITLE
Remove call to `test_examples()`

### DIFF
--- a/tests/test-all.R
+++ b/tests/test-all.R
@@ -1,4 +1,3 @@
 library(testthat)
 
 test_check("kimisc")
-test_examples()


### PR DESCRIPTION
There is already another call to `test_examples()` in
https://github.com/krlmlr/kimisc/blob/master/tests/testthat/test-kimisc.R#L3,
and this one will now cause an error in the soon to be released testthat
release, as `test_examples()` expects to be run from the
`tests/testthat` directory with the default arguments.