### PR TITLE
fledge: CRAN pre-release v0.99.99.9900

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: kimisc
 Title: Kirill's Miscellaneous Functions
-Version: 0.4.0.9000
+Version: 0.99.99.9900
 Date: 2024-11-30
 Authors@R: 
     person("Kirill", "Müller", , "krlmlr+r@mailbox.org", role = c("aut", "cre"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: Kirill's Miscellaneous Functions
 Version: 0.99.99.9900
 Date: 2024-11-30
 Authors@R: 
-    person("Kirill", "Müller", , "krlmlr+r@mailbox.org", role = c("aut", "cre"))
+    person("Kirill", "Müller", email = "kirill@cynkra.com", role = c("aut", "cre"))
 Description: A collection of useful functions not found anywhere else,
     mainly for programming: Pretty intervals, generalized lagged
     differences, checking containment in an interval, and an alternative

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# kimisc 0.4.0.9000 (2024-11-30)
+# kimisc 0.99.99.9900 (2024-11-30)
 
 ## Chore
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,9 +4,9 @@
 
 ## Chore
 
-- Upkeep, relicense as MIT (#14, #16).
+- Upkeep (#14, #16).
 
-- Fix check (#15).
+- Relicense as MIT (#14, #16).
 
 
 kimisc 0.4 (2017-12-17)

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -22,3 +22,10 @@ reference:
   contents:
     - kimisc-deprecated
 
+authors:
+  Kirill Müller:
+    href: https://krlmlr.info
+
+development:
+  mode:
+    auto

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,13 +1,5 @@
-## Test environments
-* local Ubuntu 17.10 install, R 3.4.3
-* win-builder (devel and release)
+kimisc 0.99.99.9900
 
-## R CMD check results
+## Cran Repository Policy
 
-0 errors | 0 warnings | 1 note
-
-* Spelling of my first name
-
-## Reverse dependencies
-
-* I have run R CMD check on the one downstream dependency with no failures.
+- [x] Reviewed CRP last edited 2024-08-27.

--- a/man/kimisc-package.Rd
+++ b/man/kimisc-package.Rd
@@ -18,7 +18,7 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Kirill Müller \email{krlmlr+r@mailbox.org}
+\strong{Maintainer}: Kirill Müller \email{kirill@cynkra.com}
 
 }
 \keyword{internal}


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2024-11-30, no problems found.

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`