### PR TITLE
test: replace deprecated `.Label` with `levels` in `cut_format()` tests

### DIFF
--- a/tests/testthat/test-cut.R
+++ b/tests/testthat/test-cut.R
@@ -23,7 +23,7 @@ test_that("cut is better", {
     cut_format(x, breaks),
     structure(
       c(1L, 2L, 2L, 3L, 4L),
-      .Label = c("(0.00, 0.25]", "(0.25, 0.50]", "(0.50, 0.75]", "(0.75, 1.00]"),
+      levels = c("(0.00, 0.25]", "(0.25, 0.50]", "(0.50, 0.75]", "(0.75, 1.00]"),
       class = "factor"
     )
   )
@@ -36,7 +36,7 @@ test_that("custom parentheses", {
     cut_format(x, breaks, paren = c("<", "{", ">", "}")),
     structure(
       c(1L, 2L, 2L, 3L, 4L),
-      .Label = c("<0.00, 0.25}", "<0.25, 0.50}", "<0.50, 0.75}", "<0.75, 1.00}"),
+      levels = c("<0.00, 0.25}", "<0.25, 0.50}", "<0.50, 0.75}", "<0.75, 1.00}"),
       class = "factor"
     )
   )


### PR DESCRIPTION
## Problem

The `rcc` workflow's R-devel matrix leg (`rcc: windows-latest (devel)`) has been failing since 2026-07-16. The same commit passed through 2026-07-15, confirming an upstream R change rather than a code regression.

R-devel's `checking R code for possible problems` check now flags calls to `structure()` that use deprecated special names:

```
❯ checking R code for possible problems ... NOTE
  Found calls to structure() using deprecated special names:
    kimisc/tests/testthat/test-cut.R (.Label: 2)
  '.Label' should be changed to 'levels'.

0 errors ✔ | 0 warnings ✔ | 1 note ✖
```

Because CI runs `rcmdcheck(..., error_on = "note")`, this single NOTE fails the check.

## Fix

`.Label` is a legacy `structure()` alias for the `levels` attribute, so replacing `.Label =` with `levels =` in the two factor constructions in `tests/testthat/test-cut.R` produces identical factor objects. The affected `expect_identical()` assertions continue to hold on all R versions.

## Verification

- Local `R CMD check` (R 4.5.3) with the fix: `checking R code for possible problems ... OK`, `checking tests ... OK`. The only remaining NOTE is the CRAN-incoming/URL feasibility check, which is a sandbox-network artifact (proxy 403) and does not occur on CI.
- On stock R 4.5.3 the NOTE is not emitted (the new check is R-devel only), consistent with only the `(devel)` matrix leg failing in CI. The change is a no-op on current R and removes the NOTE on R-devel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BRYo2D5L4wpgaTFTHH2B7

---
_Generated by [Claude Code](https://claude.ai/code/session_016BRYo2D5L4wpgaTFTHH2B7)_